### PR TITLE
hotfix - non existent arduino IDE when on a basic Stretch

### DIFF
--- a/Script/install.sh
+++ b/Script/install.sh
@@ -159,15 +159,10 @@ update_settings(){
 }
 
 install_arduino_avrdude_stretch() {
-    # Not installing arduino because it seems to be already in.
-    # Also bbecause anyone who wants to program in the Arduino IDE
-    # will use the GUI version of Stretch which already has the 
-    # Arduino IDE installed - so no point in installing it
-
     echo " "
     feedback "Installing Dependencies"
     feedback "======================="
-    sudo apt-get install git libi2c-dev i2c-tools minicom python-pip python-serial python-rpi.gpio python-smbus \
+    sudo apt-get install arduino git libi2c-dev i2c-tools minicom python-pip python-serial python-rpi.gpio python-smbus \
                         python3-pip python3-serial python3-rpi.gpio python3-smbus -y
     feedback "Dependencies installed"
 


### PR DESCRIPTION
If basic Stretch is used then no is Arduino IDE is installed. This isn't the case for Raspbian For Robots though.